### PR TITLE
Default Explorers + Layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ your address or block hash. It is also open source.
 #### Installing and Running
 1. Install python3 and [praw](https://praw.readthedocs.io/en/latest/getting_started/installation.html).
 2. Install the package `moreutils` for your distro.
-3. Create a [praw.ini](https://praw.readthedocs.io/en/latest/getting_started/configuration/prawini.html#defining-additional-sites) file, with the botname `nanodelinkbot`.
+3. Copy `praw.example.ini` as `praw.ini` and edit the values. You get the OAuth values from [Reddit Apps](https://www.reddit.com/prefs/apps).
 4. Create a file called `replied_posts.txt`.
-5. Change `ALLOW_POSTS` in `nanodelinkbot.py:20` to `True` to allow actually posting to reddit.
+5. Set the environment variable `ALLOW_POSTS` to `True` to allow actually posting to reddit.
 6. Excecute script `runs.sh` to monitor submissions or `runc.sh` for comments.
 

--- a/nanodelinkbot.py
+++ b/nanodelinkbot.py
@@ -37,24 +37,23 @@ BLACKLIST_BODY = [r"^!nano_tip\b"]
 BLACKLIST_SELFTEXT = []
 
 # Explorer information
-DEFAULT_EXPLORER = "nanode"
-ALL_EXPLORERS = False  # if true will add all other explorers to the reply
+DEFAULT_EXPLORER = "nanocrawler"
+ALL_EXPLORERS = True  # if true will add all other explorers to the reply
 EXPLORER_URLS = {
     "nanode": {
+        "name": "Nanode.co",
         "address": "https://nanode.co/account/%s",
         "block": "https://www.nanode.co/block/%s"
     },
     "nanocrawler": {
+        "name": "NanoCrawler.cc",
         "address": "https://nanocrawler.cc/explorer/account/%s",
         "block": "https://nanocrawler.cc/explorer/block/%s"
     },
     "nanoninja": {
+        "name": "My Nano Ninja",
         "address": "https://mynano.ninja/account/%s",
         "block": "https://mynano.ninja/block/%s"
-    },
-    "nanowatch": {
-        "address": "https://nanowat.ch/account/%s",
-        "block": "https://nanowat.ch/block/%s"
     }
 }
 
@@ -166,13 +165,13 @@ def create_body_entry(etype, value):
     :param value: The address or block
     :return: A string with the markdown url corresponding to the value
     """
-    main_url = "[%s](%s)" % (value, (EXPLORER_URLS[DEFAULT_EXPLORER][etype] % value))
+    main_url = "%s\n\n[%s](%s)" % (value, EXPLORER_URLS[DEFAULT_EXPLORER]["name"], (EXPLORER_URLS[DEFAULT_EXPLORER][etype] % value))
     second_urls = ""
     if ALL_EXPLORERS:
         for key, explorer in EXPLORER_URLS.items():
             if key == DEFAULT_EXPLORER:
                 continue
-            second_urls += "[(%s)](%s) " % (key, (explorer[etype] % value))
+            second_urls += "| [%s](%s) " % (explorer["name"], (explorer[etype] % value))
     return main_url + " " + second_urls
 
 

--- a/praw.example.ini
+++ b/praw.example.ini
@@ -1,0 +1,6 @@
+[nanodelinkbot]
+client_id=yourclientid
+client_secret=yourverylongoauthsecret
+user_agent=NanoLinkBot
+password=supersecretpassword
+username=myuser


### PR DESCRIPTION
I love the bot but I always struggled with the link it provided as Nanode didn't get any updates since over a year, NanoCrawler is way more advanced.
Additionally, both don't provide any representative information. I would prefer showing all explorers with their name (I left the identifier as is).

While digging through I saw some issues with the docs, they are fixed too.